### PR TITLE
Placeholder Generator Image Size Parameters

### DIFF
--- a/tools/generate-images.js
+++ b/tools/generate-images.js
@@ -16,12 +16,12 @@ var width = parseInt(GetParamaterValue("width"));
 var height = parseInt(GetParamaterValue("height"));
 
 
-if(width <= 0) {
+if(width <= 0 || isNaN(width)) {
   width = 800;
   console.log("Width must be a number above 0.");
 }
 
-if(height <= 0) {
+if(height <= 0 || isNaN(height)) {
   height = 600;
   console.log("Height must be a number above 0.");
 }

--- a/tools/generate-images.js
+++ b/tools/generate-images.js
@@ -6,8 +6,8 @@ function GetParamaterValue(param) {
     var position = process.argv.indexOf(param,2);
     if(position != -1 && process.argv.length >= position+2) {
       var value = process.argv[position+1];
+      return value;
     }
-    return value;
   }
   return -1;
 }
@@ -17,10 +17,12 @@ var height = parseInt(GetParamaterValue("height"));
 
 
 if(width <= 0) {
+  width = 800;
   console.log("Width must be a number above 0.");
 }
 
 if(height <= 0) {
+  height = 600;
   console.log("Height must be a number above 0.");
 }
 

--- a/tools/generate-images.js
+++ b/tools/generate-images.js
@@ -1,8 +1,31 @@
 var fs = require('fs');
 var imgGen = require('js-image-generator');
 
+function GetParamaterValue(param) {
+  if(process.argv != null) {
+    var position = process.argv.indexOf(param,2);
+    if(position != -1 && process.argv.length >= position+2) {
+      var value = process.argv[position+1];
+    }
+    return value;
+  }
+  return -1;
+}
+
+var width = parseInt(GetParamaterValue("width"));
+var height = parseInt(GetParamaterValue("height"));
+
+
+if(width <= 0) {
+  console.log("Width must be a number above 0.");
+}
+
+if(height <= 0) {
+  console.log("Height must be a number above 0.");
+}
+
 // Generate one image
-imgGen.generateImage(800, 600, 80, function(error, image) {
+imgGen.generateImage(width, height, 80, function(error, image) {
   if (error) console.log(error.stack);
   fs.writeFileSync('src/images/placeholder.jpg', image.data);
 });


### PR DESCRIPTION
Fixes #11 

Allows for width and height to be specified when generating placeholder images

- Width and height parameters allowed using "width [value]" and "height [value]"
- If no width or height are specified the default values of 800 and 600 are used respectively