### PR TITLE
Use webpack-dev-server for watch and watch template changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",
-    "watch": "cross-env NODE_ENV=development webpack --watch",
+    "build:dev": "cross-env NODE_ENV=development webpack",
+    "watch": "cross-env NODE_ENV=development webpack-dev-server --watch",
     "start": "cross-env NODE_ENV=development webpack-dev-server --open",
     "test": "run-s lint:css lint:scss lint:js",
     "lint": "run-s lint:styles lint:js",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,6 +21,13 @@ import 'bootstrap/dist/js/bootstrap.bundle'; /* Includes popper.js */
 // import 'bootstrap/js/dist/tooltip'; /* requires popper.js - Uncomment 'popper.js' in webpack.config.js */
 // import 'bootstrap/js/dist/util';
 
+/* If in development mode, watch for changes to html files */
 if (process.env.NODE_ENV === 'development') {
-  require('../index.html'); /* Require so webpack watches changes to html file */
+  const glob = require('glob');
+  const path = require('path');
+
+  require('../index.html');
+  glob.sync('./templates/**/*.js').forEach(function(file) {
+    require(path.resolve(file));
+  });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -204,6 +204,9 @@ module.exports = () => {
                   }]
                 }
               ]
+            },
+            node: {
+              fs: 'empty'
             }
           });
         }


### PR DESCRIPTION
## Description

Fixes #163 

- Changed `npm run watch` to use webpack-dev-server
- Index.html & .html files added to template paths now detect changes if NODE_ENV=development
- Added `npm run build:dev` option to debug non-server output
